### PR TITLE
Minor permission based fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ docker-compose exec packagist /srv/app/console doctrine:schema:create
 Please create your account and add some composer package.
 
 ```
-docker-compose exec packagist /srv/app/console packagist:update --no-debug --env=prod --force
-docker-compose exec packagist /srv/app/console packagist:dump --no-debug --env=prod --force
+docker-compose exec --user www-data packagist /srv/app/console packagist:update --no-debug --env=prod --force
+docker-compose exec --user www-data packagist /srv/app/console packagist:dump --no-debug --env=prod --force
 ```
 
 Attribute `force` is needed for the first-run.

--- a/packagist/entrypoint.sh
+++ b/packagist/entrypoint.sh
@@ -132,7 +132,7 @@ if [ -d "${PACKAGIS_ROOT_DIR}" ]; then
 
     mkdir -p "${PACKAGIS_ROOT_DIR}/web"
     echo "[PACKAGIST] Setup owerneship for ${PACKAGIS_ROOT_DIR}/web"
-    chmod ${USER_NAME}:${USER_NAME} "${PACKAGIS_ROOT_DIR}/web"
+    chown -R ${USER_NAME}:${USER_NAME} "${PACKAGIS_ROOT_DIR}/web"
 else
     echo "[PACKAGIST] Skip setup of packagist APP directories" 
 fi


### PR DESCRIPTION
As per commit note: Small change of 'chmod' to 'chown' as was incorrect and change of initial exec commands to run as the www-data user as was causing root ownership issues as the index would then fail to symlink correctly as cache folders were owned by root after running. (Note this doesn't occur unless you run this command)