### PR TITLE
Fix Packagist Alpine repositories

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,56 +1,105 @@
-name: Docker
+name: "Docker"
 
 on:
+  workflow_dispatch:
+
   push:
-    branches: 
-      - "master"
+    branches: ["master"]
+
+  pull_request:
+
+  schedule:
+    - cron: "0 8 * * 1"
 
 permissions:
   contents: read
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  test:
+    name: "Test (${{ matrix.app }})"
+    runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: "packagist"
+            smoke: "php -v && composer --version && test -f /srv/app/config/parameters.yml.dist"
+          - app: "solr"
+            smoke: "java -version && test -f /opt/solr/server/solr/configsets/data_driven_schema_configs/conf/managed-schema"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Validate compose file"
+        run: "docker compose config"
+
+      - name: "Build image for testing"
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ matrix.app }}"
+          load: true
+          tags: "dockette/packagist:${{ matrix.app }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: "Smoke test image"
+        run: "docker run --rm dockette/packagist:${{ matrix.app }} sh -lc '${{ matrix.smoke }}'"
+
+  build:
+    name: "Build (${{ matrix.app }})"
+    needs: ["test"]
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
       matrix:
         include:
           - app: "packagist"
           - app: "solr"
 
-      fail-fast: false
-
-    name: Docker (dockette/packagist:${{ matrix.app }})
-
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: Login to DockerHub
+      - name: "Login to DockerHub"
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
+      - name: "Set up QEMU"
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
+      - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.app }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build and push
+      - name: "Build and push"
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.app  }}
-          push: true
-          tags: dockette/packagist:${{ matrix.app }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          platforms: linux/amd64,linux/arm64
+          context: "${{ matrix.app }}"
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: "dockette/packagist:${{ matrix.app }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: "linux/amd64,linux/arm64"
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/packagist"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 DOCKER_IMAGE=dockette/packagist
 
+build: docker-build-packagist docker-build-solr
+
+test: test-compose test-packagist test-solr
+
+run:
+	docker compose up
+
 _docker-build-%: APP=$*
 _docker-build-%:
 	docker build \
@@ -10,3 +17,11 @@ _docker-build-%:
 docker-build-packagist: _docker-build-packagist
 docker-build-solr: _docker-build-solr
 
+test-compose:
+	docker compose config
+
+test-packagist:
+	docker run --rm ${DOCKER_IMAGE}:packagist sh -lc 'php -v && composer --version && test -f /srv/app/config/parameters.yml.dist'
+
+test-solr:
+	docker run --rm ${DOCKER_IMAGE}:solr sh -lc 'java -version && test -f /opt/solr/server/solr/configsets/data_driven_schema_configs/conf/managed-schema'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Packagist
+<h1 align=center>Dockette / Packagist</h1>
+
+<p align=center>
+   <a href="https://github.com/dockette/packagist/actions"><img src="https://github.com/dockette/packagist/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/packagist"><img src="https://img.shields.io/docker/pulls/dockette/packagist.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
 
 Well-prepeared Packagist docker image(s). Run you own composer packagist portal in Docker.
 
@@ -6,13 +13,6 @@ Well-prepeared Packagist docker image(s). Run you own composer packagist portal 
 > [since 2024] Use awesome self-hosted Packagist/Composer/Satis repository with unlimited private repos called [Packeton](https://bit.ly/3PosO4p).
 
 -----
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/packagist.svg?style=flat)](https://hub.docker.com/r/dockette/packagist/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/packagist.svg?style=flat)](https://hub.docker.com/r/dockette/packagist/)
-
-## Discussion / Help
-
-[![Join the chat](https://img.shields.io/gitter/room/dockette/dockette.svg?style=flat-square)](https://gitter.im/dockette/dockette?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Architecture
 
@@ -24,6 +24,8 @@ This whole project consists of 4 containers and 1 data-only container.
 - Solr (search engine)
 
 This version is [locked to](https://github.com/composer/packagist/commit/2d90743bec035e87928f4afa356ba28a1547608f) version before Packagist switched search engine to Algolia.
+
+The image is kept as a legacy stack for existing Solr-based Packagist deployments. CI intentionally uses limited Docker image and compose smoke tests instead of bootstrapping a full Packagist instance.
 
 ## Installation
 
@@ -102,4 +104,5 @@ Cron is configured per 1 minute. You can change by replacing these files:
 - /etc/periodic/1min/packagist
 
 ## Maintenance
+
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/packagist/Dockerfile
+++ b/packagist/Dockerfile
@@ -9,10 +9,10 @@ ENV USER_WORKDIR=/var/www
 ENV PACKAGIST_DIR=/srv
 ENV CRON_LOG_FILE=/var/log/cron.log
 
-RUN apk update && \
-    echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-    echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
-    apk upgrade && \
+RUN printf '%s\n' \
+    'https://dl-cdn.alpinelinux.org/alpine/v3.7/main' \
+    'https://dl-cdn.alpinelinux.org/alpine/v3.7/community' \
+    > /etc/apk/repositories && \
     # USER #####################################################################
     addgroup -g ${USER_ID} -S ${USER_NAME} && \
     adduser -u ${USER_ID} -D -h ${USER_WORKDIR} -S -G ${USER_NAME} ${USER_NAME} && \
@@ -26,35 +26,35 @@ RUN apk update && \
     openssl \
     openssh \
     nginx \
-    php7@testing \
-    php7-bcmath@testing \
-    php7-bz2@testing \
-    php7-calendar@testing \
-    php7-ctype@testing \
-    php7-curl@testing \
-    php7-dom@testing \
-    php7-fileinfo@testing \
-    php7-fpm@testing \
-    php7-gd@testing \
-    php7-iconv@testing \
-    php7-imap@testing \
-    php7-intl@testing \
-    php7-json@testing \
-    php7-mbstring@testing \
-    php7-mcrypt@testing \
-    php7-mysqli@testing \
-    php7-mysqlnd@testing \
-    php7-openssl@testing \
-    php7-phar@testing \
-    php7-pdo@testing \
-    php7-pdo_mysql@testing \
-    php7-session@testing \
-    php7-simplexml@testing \
-    php7-tokenizer@testing \
-    php7-xmlwriter@testing \
-    php7-zip@testing \
-    php7-xml@testing \
-    php7-xmlreader@testing && \
+    php7 \
+    php7-bcmath \
+    php7-bz2 \
+    php7-calendar \
+    php7-ctype \
+    php7-curl \
+    php7-dom \
+    php7-fileinfo \
+    php7-fpm \
+    php7-gd \
+    php7-iconv \
+    php7-imap \
+    php7-intl \
+    php7-json \
+    php7-mbstring \
+    php7-mcrypt \
+    php7-mysqli \
+    php7-mysqlnd \
+    php7-openssl \
+    php7-phar \
+    php7-pdo \
+    php7-pdo_mysql \
+    php7-session \
+    php7-simplexml \
+    php7-tokenizer \
+    php7-xmlwriter \
+    php7-zip \
+    php7-xml \
+    php7-xmlreader && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
     git clone https://github.com/composer/packagist.git /srv && \


### PR DESCRIPTION
## Summary
- replace untrusted Alpine edge repositories with trusted Alpine 3.7 main/community repositories
- remove edge package pins from Packagist image build

## Verification
- `make -n build test`
- `docker compose config`